### PR TITLE
Remove barrel export to avoid breaking import conditions resolution

### DIFF
--- a/.changeset/red-hands-end.md
+++ b/.changeset/red-hands-end.md
@@ -1,0 +1,5 @@
+---
+"stack54": patch
+---
+
+Remove components barrel export to avoid breaking import conditions resolution

--- a/integrations/express/test/custom-entry/src/views/components/document.svelte
+++ b/integrations/express/test/custom-entry/src/views/components/document.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <!DOCTYPE html>

--- a/integrations/express/test/default/src/views/components/document.svelte
+++ b/integrations/express/test/default/src/views/components/document.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <!DOCTYPE html>

--- a/integrations/express/test/default/src/views/stream-await.svelte
+++ b/integrations/express/test/default/src/views/stream-await.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import { delay } from "./utils";
 </script>
 

--- a/integrations/express/test/default/src/views/stream-direct.svelte
+++ b/integrations/express/test/default/src/views/stream-direct.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Await from "stack54/components/Await";
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import { delay } from "./utils";
 </script>
 

--- a/integrations/express/test/invalid-entry/src/views/components/document.svelte
+++ b/integrations/express/test/invalid-entry/src/views/components/document.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <!DOCTYPE html>

--- a/integrations/hono/test/custom-entry/src/views/components/document.svelte
+++ b/integrations/hono/test/custom-entry/src/views/components/document.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <!DOCTYPE html>

--- a/integrations/hono/test/default/src/views/components/document.svelte
+++ b/integrations/hono/test/default/src/views/components/document.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <!DOCTYPE html>

--- a/integrations/hono/test/invalid-entry/src/views/components/document.svelte
+++ b/integrations/hono/test/invalid-entry/src/views/components/document.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <!DOCTYPE html>

--- a/integrations/streaming/test/app/src/views/components/document.svelte
+++ b/integrations/streaming/test/app/src/views/components/document.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <!DOCTYPE html>

--- a/integrations/streaming/test/app/src/views/stream-await-error.svelte
+++ b/integrations/streaming/test/app/src/views/stream-await-error.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import { delay } from "./utils";
 </script>
 

--- a/integrations/streaming/test/app/src/views/stream-await-fast.svelte
+++ b/integrations/streaming/test/app/src/views/stream-await-fast.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import { delay } from "./utils";
   const promise = delay(1000);
 </script>

--- a/integrations/streaming/test/app/src/views/stream-await-then.svelte
+++ b/integrations/streaming/test/app/src/views/stream-await-then.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import { delay } from "./utils";
 </script>
 

--- a/integrations/streaming/test/app/src/views/stream-await.svelte
+++ b/integrations/streaming/test/app/src/views/stream-await.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import { delay } from "./utils";
 </script>
 

--- a/integrations/streaming/test/app/src/views/stream-direct.svelte
+++ b/integrations/streaming/test/app/src/views/stream-direct.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Await from "stack54/components/Await";
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import { delay } from "./utils";
 </script>
 

--- a/packages/core/components/ClientOnly.ts
+++ b/packages/core/components/ClientOnly.ts
@@ -1,0 +1,1 @@
+export { default as ClientOnly } from "./ClientOnly.svelte";

--- a/packages/core/components/index.ts
+++ b/packages/core/components/index.ts
@@ -1,4 +1,0 @@
-export { default as Head } from "./Head.svelte";
-export { default as Await } from "./Await/index.js";
-export { default as LiveReload } from "./LiveReload.svelte";
-export { default as ClientOnly } from "./ClientOnly.svelte";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,7 +87,6 @@
     "./config": "./dist/exports/config.js",
     "./components/Head": "./components/Head.ts",
     "./components/LiveReload": "./components/LiveReload.ts",
-    "./components": "./components/index.ts",
     "./components/*": "./components/*.svelte",
     "./internals": "./dist/exports/internals.js",
     "./render": "./dist/runtime/render/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,6 +87,7 @@
     "./config": "./dist/exports/config.js",
     "./components/Head": "./components/Head.ts",
     "./components/LiveReload": "./components/LiveReload.ts",
+    "./components/ClientOnly": "./components/ClientOnly.ts",
     "./components/*": "./components/*.svelte",
     "./internals": "./dist/exports/internals.js",
     "./render": "./dist/runtime/render/index.js",

--- a/packages/core/test/apps/basic/src/views/client-only/client-only.svelte
+++ b/packages/core/test/apps/basic/src/views/client-only/client-only.svelte
@@ -1,7 +1,7 @@
 <script island="idle">
-  import { ClientOnly } from "stack54/components";
+  import { ClientOnly } from "stack54/components/ClientOnly";
 </script>
 
 <ClientOnly>
-   <p data-testid="client-only">Client only</p>
+  <p data-testid="client-only">Client only</p>
 </ClientOnly>

--- a/packages/core/test/apps/basic/src/views/components/document.svelte
+++ b/packages/core/test/apps/basic/src/views/components/document.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <!DOCTYPE html>

--- a/packages/core/test/apps/basic/src/views/head/has-head.svelte
+++ b/packages/core/test/apps/basic/src/views/head/has-head.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
 </script>
 
 <svelte:head>

--- a/packages/core/test/apps/basic/src/views/leaf/page.svelte
+++ b/packages/core/test/apps/basic/src/views/leaf/page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import Counter from "./counter.svelte";
 </script>
 

--- a/templates/express/src/views/components/document.svelte
+++ b/templates/express/src/views/components/document.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Head, LiveReload } from "stack54/components";
+  import { Head } from "stack54/components/Head";
+  import { LiveReload } from "stack54/components/LiveReload";
 </script>
 
 <!DOCTYPE html>

--- a/templates/hono/src/views/components/document.svelte
+++ b/templates/hono/src/views/components/document.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Head, LiveReload } from "stack54/components";
+  import { Head } from "stack54/components/Head";
+  import { LiveReload } from "stack54/components/LiveReload";
 </script>
 
 <!DOCTYPE html>

--- a/templates/htmx/src/views/components/document.entry.svelte
+++ b/templates/htmx/src/views/components/document.entry.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Head, LiveReload } from "stack54/components";
+  import { Head } from "stack54/components/Head";
+  import { LiveReload } from "stack54/components/LiveReload";
 </script>
 
 <!DOCTYPE html>

--- a/templates/htmx/src/views/contact.page.svelte
+++ b/templates/htmx/src/views/contact.page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Head } from "stack54/components";
+  import { Head } from "stack54/components/Head";
   import type { User } from "../types/user";
 
   export let user: User;

--- a/templates/standalone/resources/views/components/document.entry.svelte
+++ b/templates/standalone/resources/views/components/document.entry.svelte
@@ -1,33 +1,30 @@
 <script lang="ts">
-    import { Head, LiveReload } from "stack54/components";
+  import { Head } from "stack54/components/Head";
+  import { LiveReload } from "stack54/components/LiveReload";
 </script>
 
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            crossorigin=""
-        />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
 
-        <link
-            href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap"
-            rel="stylesheet"
-        />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap"
+      rel="stylesheet"
+    />
 
-        <link rel="stylesheet" href="../styles/tailwind.css" />
+    <link rel="stylesheet" href="../styles/tailwind.css" />
 
-        <Head />
-        <LiveReload />
+    <Head />
+    <LiveReload />
 
-        <slot name="head" />
-    </head>
-    <body>
-        <slot />
-    </body>
+    <slot name="head" />
+  </head>
+  <body>
+    <slot />
+  </body>
 </html>

--- a/templates/tailwindcss/src/views/components/document.entry.svelte
+++ b/templates/tailwindcss/src/views/components/document.entry.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Head, LiveReload } from "stack54/components";
+  import { Head } from "stack54/components/Head";
+  import { LiveReload } from "stack54/components/LiveReload";
 </script>
 
 <!DOCTYPE html>


### PR DESCRIPTION
Users can import some components from the barrel export in components directory, which breaks import conditions required by the `Await` component to work correctly in SSR mode.

Closes #229 